### PR TITLE
Add a method for changing Lasertower equipment

### DIFF
--- a/X3_Customizer/Transforms/T_Obj_Code/Misc.py
+++ b/X3_Customizer/Transforms/T_Obj_Code/Misc.py
@@ -1204,9 +1204,7 @@ def Set_LaserTower_Equipment(
     orbital_laser_laser_count  = Int_To_Hex_String(orbital_laser_laser_count, 1)
     orbital_laser_shield_type  = Int_To_Hex_String(orbital_laser_shield_type, 1)
     orbital_laser_shield_count = Int_To_Hex_String(orbital_laser_shield_count, 1)
-    
-    # Lay out the replacement region, capturing both values (otherwise
-    #  ambiguity problems crop up).
+
     patch_fields = [
         # TM. Inherits from SHIP_BIG.
         [

--- a/X3_Customizer/Transforms/T_Obj_Code/Misc.py
+++ b/X3_Customizer/Transforms/T_Obj_Code/Misc.py
@@ -1152,3 +1152,95 @@ def _Show_Pirate_Yaki_Nororiety():
     Apply_Obj_Patch(patch)
 
     return
+
+@File_Manager.Transform_Wrapper('L/x3story.obj', LU = False, TC = False)
+def Set_LaserTower_Equipment(
+        lasertower_laser_type = 25,
+        lasertower_laser_count = 1,
+        lasertower_shield_type = 4,
+        lasertower_shield_count = 1,
+        orbital_laser_laser_type = 25,
+        orbital_laser_laser_count = 2, 
+        orbital_laser_shield_type = 4,
+        orbital_laser_shield_count = 1,
+    ):
+    '''
+    Sets laser type and count for lasertowers
+    
+    * lasertower_laser_type
+      - Int, argon lasertower laser type.
+    * lasertower_laser_count
+      - Int, argon lasertower laser count.
+    * lasertower_shield_type
+      - Int, argon lasertower shield type.
+    * lasertower_shield_count
+      - Int, argon lasertower shield count.
+    * orbital_laser_laser_type
+      - Int, terran orbital laser laser type.
+    * orbital_laser_laser_count
+      - Int, terran orbital laser laser count.
+    * orbital_laser_shield_type
+      - Int, terran orbital laser shield type.
+    * orbital_laser_shield_count
+      - Int, terran orbital laser shield count.
+    '''
+    # Make input args ints, limit to 1 to max_count.
+    max_count = 127
+    lasertower_laser_type      = max(1, min(int(lasertower_laser_type), max_count))
+    lasertower_laser_count     = max(1, min(int(lasertower_laser_count), max_count))
+    lasertower_shield_type     = max(1, min(int(lasertower_shield_type), max_count))
+    lasertower_shield_count    = max(1, min(int(lasertower_shield_count), max_count))
+    orbital_laser_laser_type   = max(1, min(int(orbital_laser_laser_type), max_count))
+    orbital_laser_laser_count  = max(1, min(int(orbital_laser_laser_count), max_count))
+    orbital_laser_shield_type  = max(1, min(int(orbital_laser_shield_type), max_count))
+    orbital_laser_shield_count = max(1, min(int(orbital_laser_shield_count), max_count))
+
+    # Convert to hex strings, 1 byte each.
+    lasertower_laser_type      = Int_To_Hex_String(lasertower_laser_type, 1)
+    lasertower_laser_count     = Int_To_Hex_String(lasertower_laser_count, 1)
+    lasertower_shield_type     = Int_To_Hex_String(lasertower_shield_type, 1)
+    lasertower_shield_count    = Int_To_Hex_String(lasertower_shield_count, 1)
+    orbital_laser_laser_type   = Int_To_Hex_String(orbital_laser_laser_type, 1)
+    orbital_laser_laser_count  = Int_To_Hex_String(orbital_laser_laser_count, 1)
+    orbital_laser_shield_type  = Int_To_Hex_String(orbital_laser_shield_type, 1)
+    orbital_laser_shield_count = Int_To_Hex_String(orbital_laser_shield_count, 1)
+    
+    # Lay out the replacement region, capturing both values (otherwise
+    #  ambiguity problems crop up).
+    patch_fields = [
+        # TM. Inherits from SHIP_BIG.
+        [
+            '6E' '0004'                    '..'  '05'                  '..' '03' '88' '000B09F0' 
+            '24'                   '..' '05'                  '..' '03' '88' '000B0BBA' '24' '01' '83'
+            '6E' '0003' '0D' '0004' '02' '88' '000AF243', 
+            '..' '....'+lasertower_shield_count+'..'+lasertower_shield_type+'..' '..' '........'
+            '..'+lasertower_laser_count+'..'+lasertower_laser_type+'..' '..' '........' '..' '..' '..'
+            '..' '....' '..' '....' '..' '..' '........'
+        ],
+        
+        # Capitals, inherit from Obj_2019.
+        [
+            '6E' '0001' '07' '00100071' '83' '01' '83'
+            '6E0004'                    '..'  '05'                  '..' '03' '88' '000B09F0' 
+            '24'                   '..' '05'                  '..' '03' '88' '000B0BBA' '24' '01' '83',
+            '..' '....' '..' '........' '..' '..' '..' 
+            '......'+lasertower_shield_count+'..'+lasertower_shield_type+'..' '..' '........'
+            '..'+lasertower_laser_count+'..'+lasertower_laser_type+'..' '..' '........' '..' '..' '..'
+        ],
+    ]
+    
+    # Construct the patches.
+    patch_list = []
+    for ref_code, replacement in patch_fields:
+        patch_list.append( Obj_Patch(
+            file = 'L/x3story.obj',
+            #offsets = [offset],
+            ref_code = ref_code,
+            new_code = replacement,
+        ))
+   
+
+    # Apply the patches.
+    Apply_Obj_Patch_Group(patch_list)
+
+    return


### PR DESCRIPTION
**Purpose**
Allow for editing shield and laser tower type and count for Lasertower both Argon and Terran.

**Notes**
I haven't yet been able to get this up and running on my Windows box so this method to transform is untested. I have done the actual transform by hand though and have verified that it works as intended.