### PR TITLE
Add transformer that causes Terran stations to produce Terran marines.

### DIFF
--- a/X3_Customizer/Transforms/T_Obj_Code/Misc.py
+++ b/X3_Customizer/Transforms/T_Obj_Code/Misc.py
@@ -1153,7 +1153,7 @@ def _Show_Pirate_Yaki_Nororiety():
 
     return
 
-@File_Manager.Transform_Wrapper('L/x3story.obj')
+@File_Manager.Transform_Wrapper('L/x3story.obj', LU = False, TC = False)
 def Make_Terran_Stations_Make_Terran_Marines(
     ):
     '''

--- a/X3_Customizer/Transforms/T_Obj_Code/Misc.py
+++ b/X3_Customizer/Transforms/T_Obj_Code/Misc.py
@@ -1152,3 +1152,31 @@ def _Show_Pirate_Yaki_Nororiety():
     Apply_Obj_Patch(patch)
 
     return
+
+@File_Manager.Transform_Wrapper('L/x3story.obj')
+def Make_Terran_Stations_Make_Terran_Marines(
+    ):
+    '''
+    Refactors STATION.CreateAddMarine first by making the failures for the
+    Pirate check and then the general race mask check use the same block
+    for selecting a random race.
+    
+    Then use the newly freed bytes for changing the race mask from a small int
+    to a large int. This allows the mask to include all possible races.
+    
+    Next we just flip the bit in the mask for terran to true and we have are end \
+    result of terran stations creating terran marines.
+    '''
+
+    patch = Obj_Patch(
+            file = 'L/x3story.obj',
+            ref_code = '01' '0F000F' '8500000D71' '0D0001' '0508' '5B' '34000950F0' '053E' '02'
+	    	       '8400007450' '140002' '24' '320009510E' '01' '0F000F' '8500004C66' '053E' 
+	               '53' '64' '340009510E' '053E' '02' '8400007450' '140002' '24' '01',
+            new_code = '01' '0F000F' '8500000D71' '0D0001' '0508' '5A' '3400095102' '0C0C' '0C'
+	               '0C0C0C0C0C' '0C0C0C' '0C' '0C0C' '01' '0F000F' '8500004C66' '070004003E' 
+	               '53' '64' '340009510E' '053E' '02' '8400007450' '140002' '24' '01',
+            )
+    Apply_Obj_Patch(patch)
+
+    return


### PR DESCRIPTION
**Purpose**
Refactors STATION.CreateAddMarine first by making the failures for the Pirate check and then the general race mask check use the same block for selecting a random race.
    
Then use the newly freed bytes for changing the race mask from a small int to a large int. This allows the mask to include all possible races.
    
Next we just flip the bit in the mask for Terran to true and we have are end result of Terran stations creating Terran marines.

**Notes**
I haven't yet been able to get this up and running on my Windows box so this method to transform is untested. I have done the actual transform by hand though and have verified that it works as intended.